### PR TITLE
Bugfix: SPA loader for non-root path

### DIFF
--- a/Src/Campus.Master.API/Startup.cs
+++ b/Src/Campus.Master.API/Startup.cs
@@ -8,6 +8,7 @@ using Campus.Infrastructure.Business.Dependencies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -100,13 +101,20 @@ namespace Campus.Master.API
             {
                 app.UseHttpsRedirection();
             }
-            
-            app.UseDefaultFiles();
-            app.UseStaticFiles();
+
             app.UseRouting();
             app.UseAuthentication();
             app.UseAuthorization();
             app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+            
+            app.UseDefaultFiles();
+            app.UseStaticFiles();
+
+            app.Run(async (context) =>
+            {
+                context.Response.ContentType = "text/html";
+                await context.Response.SendFileAsync(Path.Combine(env.WebRootPath, "index.html"));
+            });
         }
     }
 }


### PR DESCRIPTION
SPA files can be loaded only from '/' path. Other routes will lead to the error:

This campus-master.com page can’t be found. No webpage was found for the web address: https://campus-master.com/registration
HTTP ERROR 404

This hotfix solves the problem.