### PR TITLE
[Refactoring] Remove UI proxy in development mode

### DIFF
--- a/Src/Campus.Master.API/Properties/launchSettings.json
+++ b/Src/Campus.Master.API/Properties/launchSettings.json
@@ -19,6 +19,15 @@
     },
     "Campus.Master.API Development": {
       "commandName": "Project",
+      "launchBrowser": false,
+      "launchUrl": "",
+      "applicationUrl": "http://localhost:5000",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Campus.Master.API Swagger": {
+      "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5000",

--- a/Src/Campus.Master.API/Startup.cs
+++ b/Src/Campus.Master.API/Startup.cs
@@ -39,7 +39,6 @@ namespace Campus.Master.API
             string xmlDocPath = Path.Combine(AppContext.BaseDirectory, xmlDocFile);
             
             services.AddControllers();
-            services.AddCors();
             services.AddSwaggerGen(c =>
             {
                 c.SwaggerDoc(ApiVersion, new OpenApiInfo {Title = ApiTitle, Version = ApiVersion});

--- a/Src/Campus.Master.API/Startup.cs
+++ b/Src/Campus.Master.API/Startup.cs
@@ -113,8 +113,6 @@ namespace Campus.Master.API
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseCors(builder =>
-                    builder.WithOrigins(Configuration["DevUI:ProxyUrl"]).AllowAnyHeader().AllowAnyMethod());
                 app.UseSwagger();
                 app.UseSwaggerUI(c => { c.SwaggerEndpoint(Configuration["Swagger:StaticRoute"], ApiTitle); });
             }

--- a/Src/Campus.Master.API/appsettings.Development.json
+++ b/Src/Campus.Master.API/appsettings.Development.json
@@ -6,9 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "DevUI": {
-    "ProxyUrl": "http://localhost:4200"
-  },
   "Swagger": {
     "StaticRoute": "/swagger/v1.2/swagger.json"
   },

--- a/UI/Campus-UI/package.json
+++ b/UI/Campus-UI/package.json
@@ -8,6 +8,7 @@
     "build:ci": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build",
     "build:ci:prod": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build --prod",
     "build:cd": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build --prod --output-hashing=none --output-path=../../Src/Campus.Master.API/wwwroot",
+    "build:dev": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng build --output-path=../../Src/Campus.Master.API/wwwroot",
     "test": "ng test",
     "test:ci": "node --max_old_space_size=8192 ./node_modules/@angular/cli/bin/ng test --browsers=ChromeHeadless",
     "lint": "ng lint",


### PR DESCRIPTION
To run the application in dev mode use now the following command **(from the project root)**:

1) npm run build:dev --prefix UI/Campus-UI
2) dotnet run --project Src/Campus.Master.API/Campus.Master.API.csproj