### PR TITLE
feat(Master.Services): recording preferrenced language

### DIFF
--- a/Src/Campus.Domain.Core/Models/Locale.cs
+++ b/Src/Campus.Domain.Core/Models/Locale.cs
@@ -1,0 +1,9 @@
+namespace Campus.Domain.Core.Models
+{
+    public enum Locale
+    {
+        English,
+        Russian,
+        Ukrainian
+    }
+}

--- a/Src/Campus.Domain.Core/Models/User.cs
+++ b/Src/Campus.Domain.Core/Models/User.cs
@@ -8,6 +8,7 @@ namespace Campus.Domain.Core.Models
     {
         public string FullName { get; set; }
         public DateTime CreatedOn { get; set; }
+        public Locale PreferredLocale { get; set; }
 
         public ICollection<Participant> Participation { get; set; }
     }

--- a/Src/Campus.Infrastructure.Data.EntityFrameworkCore/Configs/Mapping/UserMap.cs
+++ b/Src/Campus.Infrastructure.Data.EntityFrameworkCore/Configs/Mapping/UserMap.cs
@@ -33,6 +33,11 @@ namespace Campus.Infrastructure.Data.EntityFrameworkCore.Configs.Mapping
                 .HasConversion(
                     cl => cl.ToString("o"),
                     cl => Convert.ToDateTime(cl));
+
+            builder.Property(p => p.PreferredLocale)
+                .HasConversion(
+                    locale => locale.ToString(),
+                    locale => (Locale)Enum.Parse(typeof(Locale), locale));
         }
     }
 }

--- a/Src/Campus.Master.API/Controllers/ProfileController.cs
+++ b/Src/Campus.Master.API/Controllers/ProfileController.cs
@@ -64,6 +64,7 @@ namespace Campus.Master.API.Controllers
         ///         "Email": "...",
         ///         "UserName": "...",
         ///         "FullName": "...",
+        ///         "PreferredLocale": "...", [OPTIONAL]
         ///         "Password": "...",
         ///         "ConfirmPassword": "..."
         ///     }
@@ -129,7 +130,8 @@ namespace Campus.Master.API.Controllers
         ///     Content-Type: application/json
         /// 
         ///     {
-        ///         "FullName": "..."
+        ///         "FullName": "...",
+        ///         "PreferredLocale": "..."
         ///     }
         /// 
         /// </remarks>

--- a/Src/Campus.Services.Interfaces/DTO/User/UserEditDto.cs
+++ b/Src/Campus.Services.Interfaces/DTO/User/UserEditDto.cs
@@ -3,5 +3,6 @@ namespace Campus.Services.Interfaces.DTO.User
     public class UserEditDto
     {
         public string FullName { get; set; }
+        public string PreferredLocale { get; set; }
     }
 }

--- a/Src/Campus.Services.Interfaces/DTO/User/UserRegistrationDto.cs
+++ b/Src/Campus.Services.Interfaces/DTO/User/UserRegistrationDto.cs
@@ -5,6 +5,7 @@ namespace Campus.Services.Interfaces.DTO.User
         public string Email { get; set; }
         public string UserName { get; set; }
         public string FullName { get; set; }
+        public string PreferredLocale { get; set; }
         
         public string Password { get; set; }
         public string ConfirmPassword { get; set; }

--- a/Src/Campus.Services/Infrastructure/ProfileService.cs
+++ b/Src/Campus.Services/Infrastructure/ProfileService.cs
@@ -33,12 +33,18 @@ namespace Campus.Services.Infrastructure
             if (userWithSameEmail != null || userWithSameUserName != null)
                 throw new ApplicationException("User already exists");
 
+            var rawLocale = registrationDto.PreferredLocale ?? Locale.English.ToString();
+
+            if (!Enum.TryParse(rawLocale, out Locale locale))
+                throw new ApplicationException("Failed to parse preferred user locale");
+
             var registrationResult = await _userManager.CreateAsync(new User
             {
                 Email = registrationDto.Email,
                 UserName = registrationDto.UserName,
                 FullName = registrationDto.FullName,
                 CreatedOn = DateTime.Now,
+                PreferredLocale = locale,
                 Participation = new List<Participant>
                 {
                     new Participant
@@ -107,7 +113,12 @@ namespace Campus.Services.Infrastructure
             if (user == null)
                 throw new ApplicationException("User with this ID doesn't exist");
 
+            if (!Enum.TryParse(editingDto.PreferredLocale, out Locale locale))
+                throw new ApplicationException("Failed to parse preferred user locale");
+
             user.FullName = editingDto.FullName;
+            user.PreferredLocale = locale;
+
             await _userManager.UpdateAsync(user);
         }
     }


### PR DESCRIPTION
Preferred property of locale is **optional**. To create account with default locale (English) use following request body:

`POST /api/profile/create`
```json
{
  "email": "example@mail.com",
  "userName": "John",
  "fullName": "Smith",
  "password": "Password",
  "confirmPassword": "Password"
}
```

To explicitly set default locale on registration phase use the following format of body request:

`POST /api/profile/create`
```json
{
  "email": "example@mail.com",
  "userName": "John",
  "fullName": "Smith",
  "preferredLocale": "Ukrainian",
  "password": "Password",
  "confirmPassword": "Password"
}
```

To change locale use:

`PUT /api/profile`
```json
{
    "fullName": "...",
    "preferredLocale": "..."
}
```